### PR TITLE
Corrected path to LLDB.framework

### DIFF
--- a/Source/SwiftCovFramework/coverage.py
+++ b/Source/SwiftCovFramework/coverage.py
@@ -5,7 +5,7 @@ import subprocess
 import re
 
 XCPATH = subprocess.check_output(['xcode-select', '--print-path']).strip()
-FWPATH = re.sub(r'/Developer$', r'/SharedFrameworks/LLDB.framework/Resources/Python', XCPATH).strip()
+FWPATH = re.sub(r'/Developer/$', r'/SharedFrameworks/LLDB.framework/Resources/Python', XCPATH).strip()
 sys.path.insert(0, FWPATH)
 import lldb
 


### PR DESCRIPTION
When I run swiftcov, it fails with the following error:

```
/Applications/Xcode.app/Contents/Developer/
Traceback (most recent call last):
  File "/Users/Thomas/Library/Developer/Xcode/DerivedData/SwiftCov-gfvxdndtmsexakbihbkblcqhyyyg/Build/Products/Debug/SwiftCovFramework.framework/Resources/coverage.py", line 11, in <module>
    import lldb
ImportError: No module named lldd
```

It has to do with the value XCPATH, which is then used to deduce the FWPATH. On my machine, there's a trailing forward slash in XCPATH, which resulted in a wrong path to lldb.
