### PR TITLE
Add integration tests

### DIFF
--- a/Source/SwiftCovFramework/CoverageReporter.swift
+++ b/Source/SwiftCovFramework/CoverageReporter.swift
@@ -1,0 +1,75 @@
+//
+//  CoverageReporter.swift
+//  swiftcov
+//
+//  Created by Kishikawa Katsumi on 2015/05/31.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import Foundation
+import Result
+
+public class CoverageReporter {
+    private let outputDirectory: String
+    private let threshold: Int
+    private let verbose: Bool
+
+    public init(outputDirectory: String = "", threshold: Int = 0, verbose: Bool = false) {
+        self.outputDirectory = outputDirectory
+        self.threshold = threshold
+        self.verbose = verbose
+    }
+    
+    public func runCoverageReport(buildSettings settings: BuildSettings) -> Result<String, TerminationStatus> {
+        func buildSetting(key: String) -> String? {
+            return settings.executable.buildSettings[key]
+        }
+
+        func testBundleBuildSetting(key: String) -> String? {
+            return settings.testingBundles.first?.buildSettings[key]
+        }
+
+        if let sdkName = buildSetting("SDK_NAME"),
+            let sdkroot = buildSetting("SDKROOT"),
+            let builtProductsDir = testBundleBuildSetting("BUILT_PRODUCTS_DIR"),
+            let fullProductName = testBundleBuildSetting("FULL_PRODUCT_NAME"),
+            let srcroot = buildSetting("SRCROOT"),
+            let objectFileDirNormal = buildSetting("OBJECT_FILE_DIR_normal"),
+            let currentArch = buildSetting("CURRENT_ARCH"),
+            let scriptPath = NSBundle(forClass: Shell.self).pathForResource("coverage", ofType: "py") {
+                let targetPath = builtProductsDir.stringByAppendingPathComponent(fullProductName)
+                let outputDir: String
+                if outputDirectory.isEmpty {
+                    outputDir = objectFileDirNormal.stringByAppendingPathComponent(currentArch)
+                } else {
+                    let fileManager = NSFileManager.defaultManager()
+                    var isDirectory: ObjCBool = false
+                    if !fileManager.fileExistsAtPath(outputDirectory, isDirectory: &isDirectory) || !isDirectory {
+                        fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+                    }
+                    outputDir = outputDirectory
+                }
+
+                return Shell(commandPath: "/usr/bin/xcode-select", arguments: ["--print-path"], verbose: verbose).output()
+                    .map { $0.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) }
+                    .flatMap { xcodePath -> Result<String, TerminationStatus> in
+                        let dyldFallbackFrameworkPath = "/Library/Frameworks:/Network/Library/Frameworks:/System/Library/Frameworks:\(xcodePath)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks:\(xcodePath)/Library/PrivateFrameworks:\(xcodePath)/../OtherFrameworks:\(xcodePath)/../SharedFrameworks:\(xcodePath)/Library/Frameworks:\(xcodePath)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks"
+                        let dyldFallbackLibraryPath = "\(xcodePath)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib"
+
+                        let env = [
+                            "SWIFTCOV_SDK_NAME": sdkName,
+                            "SWIFTCOV_DYLD_FRAMEWORK_PATH": builtProductsDir,
+                            "SWIFTCOV_DYLD_LIBRARY_PATH": builtProductsDir,
+                            "SWIFTCOV_DYLD_FALLBACK_FRAMEWORK_PATH": dyldFallbackFrameworkPath,
+                            "SWIFTCOV_DYLD_FALLBACK_LIBRARY_PATH": dyldFallbackLibraryPath,
+                            "SWIFTCOV_DYLD_ROOT_PATH": sdkroot,
+                            "SWIFTCOV_HIT_COUNT": "\(threshold)"
+                        ]
+                        
+                        return Shell(commandPath: "/usr/bin/python", arguments: [scriptPath, targetPath, srcroot, outputDir], environment: env, verbose: verbose).run()
+                }
+        }
+        
+        return Result(error: EXIT_FAILURE)
+    }
+}

--- a/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
+++ b/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
@@ -1,0 +1,104 @@
+//
+//  IntegrationTests.swift
+//  swiftcov
+//
+//  Created by Kishikawa Katsumi on 2015/05/31.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+import XCTest
+import SwiftCovFramework
+
+class CoverageReporterTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testGenerateCoverageReportIOS() {
+        let temporaryDirectory = NSTemporaryDirectory().stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
+        NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+
+        let reporter = CoverageReporter(outputDirectory: temporaryDirectory)
+
+        let xcodebuild = Xcodebuild(argments: ["xcodebuild",
+                                               "test",
+                                               "-project", "./Examples/ExampleFramework/ExampleFramework.xcodeproj",
+                                               "-scheme", "ExampleFramework-iOS",
+                                               "-configuration", "Release",
+                                               "-sdk", "iphonesimulator",
+                                               "-derivedDataPath", temporaryDirectory])
+        switch xcodebuild.showBuildSettings() {
+        case let .Success(output):
+            let buildSettings = BuildSettings(output: output.value)
+
+            switch xcodebuild.buildExecutable() {
+            case .Success:
+                switch reporter.runCoverageReport(buildSettings: buildSettings) {
+                case .Success:
+                    let reportFilePath = temporaryDirectory.stringByAppendingPathComponent("Calculator.swift.gcov")
+                    let fixtureFilePath = "./Examples/ExampleFramework/coverage_ios/Calculator.swift.gcov"
+
+                    XCTAssertEqual(
+                        NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding, error: nil)!,
+                        NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding, error: nil)!)
+                case let .Failure(error):
+                    XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                    XCTFail("Execution failure")
+                }
+            case let .Failure(error):
+                XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                XCTFail("Execution failure")
+            }
+        case let .Failure(error):
+            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTFail("Execution failure")
+        }
+    }
+
+    func testGenerateCoverageReportOSX() {
+        let temporaryDirectory = NSTemporaryDirectory().stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
+        NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+
+        let reporter = CoverageReporter(outputDirectory: temporaryDirectory)
+
+        let xcodebuild = Xcodebuild(argments: ["xcodebuild",
+                                               "test",
+                                               "-project", "./Examples/ExampleFramework/ExampleFramework.xcodeproj",
+                                               "-scheme", "ExampleFramework-Mac",
+                                               "-configuration", "Release",
+                                               "-sdk", "macosx",
+                                               "-derivedDataPath", temporaryDirectory])
+        switch xcodebuild.showBuildSettings() {
+        case let .Success(output):
+            let buildSettings = BuildSettings(output: output.value)
+            
+            switch xcodebuild.buildExecutable() {
+            case .Success:
+                switch reporter.runCoverageReport(buildSettings: buildSettings) {
+                case .Success:
+                    let reportFilePath = temporaryDirectory.stringByAppendingPathComponent("Calculator.swift.gcov")
+                    let fixtureFilePath = "./Examples/ExampleFramework/coverage_osx/Calculator.swift.gcov"
+                    
+                    XCTAssertEqual(
+                        NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding, error: nil)!,
+                        NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding, error: nil)!)
+                case let .Failure(error):
+                    XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                    XCTFail("Execution failure")
+                }
+            case let .Failure(error):
+                XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                XCTFail("Execution failure")
+            }
+        case let .Failure(error):
+            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTFail("Execution failure")
+        }
+    }
+
+}

--- a/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
+++ b/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
@@ -20,7 +20,11 @@ class XcodebuildTests: XCTestCase {
     }
 
     func testBuildSettings() {
-        var xcodebuild = Xcodebuild(argments: ["xcodebuild", "test", "-scheme", "SwiftCovFramework", "-configuration", "Debug", "-sdk", "macosx"])
+        let xcodebuild = Xcodebuild(argments: ["xcodebuild",
+                                               "test",
+                                               "-scheme", "SwiftCovFramework",
+                                               "-configuration", "Debug",
+                                               "-sdk", "macosx"])
 
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):

--- a/swiftcov.xcodeproj/project.pbxproj
+++ b/swiftcov.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		1401EBEA1B14B009000D8737 /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1401EBE91B14B009000D8737 /* BuildSettings.swift */; };
 		14DE82611B1B0AA900E1BAA4 /* ShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE82601B1B0AA900E1BAA4 /* ShellTests.swift */; };
 		14DE82631B1B210700E1BAA4 /* XcodebuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE82621B1B210700E1BAA4 /* XcodebuildTests.swift */; };
+		14DE82671B1B4B3D00E1BAA4 /* CoverageReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE82661B1B4B3D00E1BAA4 /* CoverageReporterTests.swift */; };
+		14DE826B1B1B4DFA00E1BAA4 /* CoverageReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE826A1B1B4DFA00E1BAA4 /* CoverageReporter.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SwiftCovFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftCovFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217219E87B05005E4BAA /* SwiftCovFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = D0D1217119E87B05005E4BAA /* SwiftCovFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0D1217819E87B05005E4BAA /* SwiftCovFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftCovFramework.framework */; };
@@ -80,6 +82,8 @@
 		1401EBE91B14B009000D8737 /* BuildSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
 		14DE82601B1B0AA900E1BAA4 /* ShellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShellTests.swift; sourceTree = "<group>"; };
 		14DE82621B1B210700E1BAA4 /* XcodebuildTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodebuildTests.swift; sourceTree = "<group>"; };
+		14DE82661B1B4B3D00E1BAA4 /* CoverageReporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverageReporterTests.swift; sourceTree = "<group>"; };
+		14DE826A1B1B4DFA00E1BAA4 /* CoverageReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoverageReporter.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -260,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				D0D1217119E87B05005E4BAA /* SwiftCovFramework.h */,
+				14DE826A1B1B4DFA00E1BAA4 /* CoverageReporter.swift */,
 				1401EBE71B14AFE2000D8737 /* Xcodebuild.swift */,
 				1401EBE91B14B009000D8737 /* BuildSettings.swift */,
 				1401EBD41B11612C000D8737 /* Shell.swift */,
@@ -284,6 +289,7 @@
 		D0D1217B19E87B05005E4BAA /* SwiftCovFrameworkTests */ = {
 			isa = PBXGroup;
 			children = (
+				14DE82661B1B4B3D00E1BAA4 /* CoverageReporterTests.swift */,
 				14DE82621B1B210700E1BAA4 /* XcodebuildTests.swift */,
 				14DE82601B1B0AA900E1BAA4 /* ShellTests.swift */,
 				D0D1212219E878CC005E4BAA /* Configuration */,
@@ -460,6 +466,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				14DE826B1B1B4DFA00E1BAA4 /* CoverageReporter.swift in Sources */,
 				1401EBE81B14AFE2000D8737 /* Xcodebuild.swift in Sources */,
 				1401EBD51B11612C000D8737 /* Shell.swift in Sources */,
 				1401EBEA1B14B009000D8737 /* BuildSettings.swift in Sources */,
@@ -472,6 +479,7 @@
 			files = (
 				14DE82631B1B210700E1BAA4 /* XcodebuildTests.swift in Sources */,
 				14DE82611B1B0AA900E1BAA4 /* ShellTests.swift in Sources */,
+				14DE82671B1B4B3D00E1BAA4 /* CoverageReporterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Create `CoverageReporter` class that delegates `runCoverageReport` method for testability
- Execute coverage generating from test cases
- Verify coverage files to compare existing files
