### PR TITLE
Workaround for failing launch simulator on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,7 @@ machine:
     version: "6.3.1"
 test:
   override:
+    - sudo chown :wheel "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 7.1.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim"
+    - sudo chown :wheel "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 8.1.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim"
+    - sudo chown :wheel "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 8.2.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim"
     - script/cibuild


### PR DESCRIPTION
It will fix the issue following:

```
2015-06-02 16:23:07.089 xcodebuild[7930:33059] [MT] iPhoneSimulator: SimVerifier returned: Error Domain=NSPOSIXErrorDomain Code=53 "Simulator verification failed." UserInfo=0x7f9523d11800 {NSLocalizedFailureReason=A connection to the simulator verification service could not be established., NSLocalizedRecoverySuggestion=Ensure that Xcode.app is installed on a volume with ownership enabled., NSLocalizedDescription=Simulator verification failed.}
```
