### PR TITLE
Added Codecov upload methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ $ gcovr --root . --use-gcov-files --html --html-details --output coverage.html -
 
 See [the generated coverage file](Examples/ExampleFramework/results/coverage.html).
 
+### Send coverage information to [codecov.io](https://codecov.io/).
+
+Use [codecov-bash](https://github.com/codecov/codecov-bash) global uploader.
+
+```yaml
+# cirlce.yml
+test:
+  override:
+    - sudo chown :wheel /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ *.simruntime/Contents/Resources/RuntimeRoot/usr/lib/dyld_sim
+    - xcodebuild test -project Example.xcodeproj -scheme 'Example' -configuration Release -sdk iphonesimulator
+    - swiftcov generage --output coverage xcodebuild test -project Example.xcodeproj -scheme 'Example' -configuration Release -sdk iphonesimulator
+  post:
+    - bash <(curl -s https://codecov.io/bash)
+```
+
 ### Send coverage information to [coveralls.io](https://coveralls.io/).
 
 - [realm/SwiftCov | Coveralls - Test Coverage History & Statistics](https://coveralls.io/r/realm/SwiftCov)


### PR DESCRIPTION
Hey, I'm the founder of Codecov and would like to add our product the the Readme to show customer that they can upload reports to us.

The global uploader will find all the `gcov` file automatically. [See how here](https://github.com/codecov/codecov-bash/blob/master/codecov#L287-L288).

Thank you!