### PR TITLE
Stop yielding the root directory

### DIFF
--- a/Source/SwiftCovFramework/coverage.py
+++ b/Source/SwiftCovFramework/coverage.py
@@ -171,7 +171,6 @@ def report_coverage(coverage_files, output_dir):
 
 def find_all_files(directory):
     for root, dirs, files in os.walk(directory):
-        yield root
         for file in files:
             yield os.path.join(root, file)
 


### PR DESCRIPTION
The root directory doesn't need to be sent along with the other files. It isn't used. This ensures that project directories with the suffix ".swift" (in libraries like Dollar.swift, Few.swift, and SQLite.swift) aren't assumed to be Swift files later in the pipeline.

Fixes #42.