### PR TITLE
Update for Xcode 7.2 and deprecate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
-# OS X
-.DS_Store
-
 # Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Build generated
 build/
+DerivedData/
+
+## Various settings
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -12,16 +15,48 @@ build/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-xcuserdata
-*.xccheckout
+xcuserdata/
+
+## Other
 *.moved-aside
-DerivedData
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
 *.hmap
 *.ipa
-*.xcuserstate
 
-SwiftCov.pkg
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
 
-# Bundler
-.bundle
-vendor/
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/screenshots

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "Carthage/Checkouts/Commandant"]
 	path = Carthage/Checkouts/Commandant
 	url = https://github.com/Carthage/Commandant.git
-[submodule "Carthage/Checkouts/Box"]
-	path = Carthage/Checkouts/Box
-	url = https://github.com/robrix/Box.git
 [submodule "Carthage/Checkouts/Result"]
 	path = Carthage/Checkouts/Result
 	url = https://github.com/antitypical/Result.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Carthage/Commandant" ~> 0.6
-github "jspahrsummers/xcconfigs" >= 0.8
+github "Carthage/Commandant"
+github "jspahrsummers/xcconfigs"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
-github "robrix/Box" "1.2.2"
-github "jspahrsummers/xcconfigs" "0.8"
-github "antitypical/Result" "0.4.3"
-github "Carthage/Commandant" "0.6"
+github "antitypical/Result" "1.0.1"
+github "jspahrsummers/xcconfigs" "0.8.1"
+github "Carthage/Commandant" "0.8.2"

--- a/Examples/ExampleFramework/ExampleFramework.xcodeproj/project.pbxproj
+++ b/Examples/ExampleFramework/ExampleFramework.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		1401EC241B15141B000D8737 /* ExampleFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExampleFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1401EC281B15141B000D8737 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1401EC291B15141B000D8737 /* ExampleFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExampleFramework.h; sourceTree = "<group>"; };
-		1401EC2F1B15141B000D8737 /* ExampleFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExampleFrameworkTests.xctest; path = ExampleFrameworkiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1401EC2F1B15141B000D8737 /* ExampleFrameworkiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleFrameworkiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1401EC351B15141B000D8737 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1401EC361B15141B000D8737 /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
 		1401EC401B151494000D8737 /* Calculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
@@ -99,7 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				1401EC241B15141B000D8737 /* ExampleFramework.framework */,
-				1401EC2F1B15141B000D8737 /* ExampleFrameworkTests.xctest */,
+				1401EC2F1B15141B000D8737 /* ExampleFrameworkiOSTests.xctest */,
 				14DE82711B1B586D00E1BAA4 /* ExampleFramework.framework */,
 				14DE827B1B1B586E00E1BAA4 /* ExampleFramework-MacTests.xctest */,
 			);
@@ -198,7 +198,7 @@
 			);
 			name = ExampleFrameworkiOSTests;
 			productName = ExampleFrameworkTests;
-			productReference = 1401EC2F1B15141B000D8737 /* ExampleFrameworkTests.xctest */;
+			productReference = 1401EC2F1B15141B000D8737 /* ExampleFrameworkiOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		14DE82701B1B586D00E1BAA4 /* ExampleFramework-Mac */ = {
@@ -243,7 +243,8 @@
 		1401EC1B1B15141B000D8737 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = kishikawakatsumi;
 				TargetAttributes = {
 					1401EC231B15141B000D8737 = {
@@ -386,6 +387,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -464,6 +466,7 @@
 				INFOPLIST_FILE = ExampleFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -481,6 +484,7 @@
 				INFOPLIST_FILE = ExampleFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -489,16 +493,14 @@
 		1401EC3E1B15141B000D8737 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = ExampleFrameworkTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -506,12 +508,10 @@
 		1401EC3F1B15141B000D8737 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ExampleFrameworkTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -534,6 +534,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -553,6 +554,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -575,6 +577,7 @@
 				INFOPLIST_FILE = ExampleFrameworkTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -591,6 +594,7 @@
 				INFOPLIST_FILE = ExampleFrameworkTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};

--- a/Examples/ExampleFramework/ExampleFramework.xcodeproj/xcshareddata/xcschemes/ExampleFramework-Mac.xcscheme
+++ b/Examples/ExampleFramework/ExampleFramework.xcodeproj/xcshareddata/xcschemes/ExampleFramework-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:ExampleFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Examples/ExampleFramework/ExampleFramework.xcodeproj/xcshareddata/xcschemes/ExampleFramework-iOS.xcscheme
+++ b/Examples/ExampleFramework/ExampleFramework.xcodeproj/xcshareddata/xcschemes/ExampleFramework-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:ExampleFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Examples/ExampleFramework/ExampleFramework/Info.plist
+++ b/Examples/ExampleFramework/ExampleFramework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Examples/ExampleFramework/ExampleFramework/Networking.swift
+++ b/Examples/ExampleFramework/ExampleFramework/Networking.swift
@@ -24,11 +24,11 @@ public class Networking {
     }
 
     public func request(completion:(data: NSData?, response: NSURLResponse, error: NSError?) -> Void) -> Void {
-        var session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())
-        var request = NSMutableURLRequest(URL: requesetURL)
+        let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())
+        let request = NSMutableURLRequest(URL: requesetURL)
 
         session.dataTaskWithRequest(request, completionHandler: { (data, response, error) -> Void in
-            completion(data: data, response: response, error: error)
+            completion(data: data, response: response!, error: error)
         }).resume()
     }
 

--- a/Examples/ExampleFramework/ExampleFrameworkTests/Info.plist
+++ b/Examples/ExampleFramework/ExampleFrameworkTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Examples/ExampleFramework/ExampleFrameworkTests/NetworkingTests.swift
+++ b/Examples/ExampleFramework/ExampleFrameworkTests/NetworkingTests.swift
@@ -33,7 +33,7 @@ class NetworkingTests: XCTestCase {
         }
 
         waitForExpectationsWithTimeout(5.0, handler: { (error) -> Void in
-            if let error = error {
+            if let _ = error {
                 XCTFail("Connection timeout")
             }
         })

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Swift 2.0 introduced native support for test coverage, so SwiftCov is now deprecated.**
+
 # SwiftCov
 
 A tool to generate test code coverage information for Swift.

--- a/Source/SwiftCovFramework/BuildSettings.swift
+++ b/Source/SwiftCovFramework/BuildSettings.swift
@@ -59,11 +59,9 @@ public struct BuildSettings {
             let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
             if matches.count == 1 {
                 for match in matches {
-                    if let match = match as? NSTextCheckingResult {
-                        target = (line as NSString).substringWithRange(match.rangeAtIndex(1))
-                        if let target = target {
-                            settings[target] = BuildSettingsDictionary()
-                        }
+                    target = (line as NSString).substringWithRange(match.rangeAtIndex(1))
+                    if let target = target {
+                        settings[target] = BuildSettingsDictionary()
                     }
                 }
             } else if let target = target {

--- a/Source/SwiftCovFramework/BuildSettings.swift
+++ b/Source/SwiftCovFramework/BuildSettings.swift
@@ -55,8 +55,8 @@ public struct BuildSettings {
         var target: String?
         var settings = [TargetName: BuildSettingsDictionary]()
         for line in lines {
-            let regex = NSRegularExpression(pattern: "^Build settings for action .+ and target (.+):$", options: nil, error: nil)!
-            let matches = regex.matchesInString(line, options: nil, range: NSRange(location: 0, length: (line as NSString).length))
+            let regex = try! NSRegularExpression(pattern: "^Build settings for action .+ and target (.+):$", options: [])
+            let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
             if matches.count == 1 {
                 for match in matches {
                     if let match = match as? NSTextCheckingResult {
@@ -67,7 +67,7 @@ public struct BuildSettings {
                     }
                 }
             } else if let target = target {
-                let kv = split(line, allowEmptySlices: true) { $0 == "=" }
+                let kv = line.characters.split(allowEmptySlices: true) { $0 == "=" }.map { String($0) }
                 let key = kv[0].stringByTrimmingCharactersInSet(whitespaceAndNewlineCharacterSet)
                 let value = kv[1].stringByTrimmingCharactersInSet(whitespaceAndNewlineCharacterSet)
                 if var s = settings[target] {

--- a/Source/SwiftCovFramework/CoverageReporter.swift
+++ b/Source/SwiftCovFramework/CoverageReporter.swift
@@ -42,15 +42,18 @@ public class CoverageReporter {
             let objectFileDirNormal = buildSetting("OBJECT_FILE_DIR_normal"),
             let currentArch = buildSetting("CURRENT_ARCH"),
             let scriptPath = NSBundle(forClass: Shell.self).pathForResource("coverage", ofType: "py") {
-                let targetPath = builtProductsDir.stringByAppendingPathComponent(fullProductName)
+                let targetPath = (builtProductsDir as NSString).stringByAppendingPathComponent(fullProductName)
                 let outputDir: String
                 if outputDirectory.isEmpty {
-                    outputDir = objectFileDirNormal.stringByAppendingPathComponent(currentArch)
+                    outputDir = (objectFileDirNormal as NSString).stringByAppendingPathComponent(currentArch)
                 } else {
                     let fileManager = NSFileManager.defaultManager()
                     var isDirectory: ObjCBool = false
                     if !fileManager.fileExistsAtPath(outputDirectory, isDirectory: &isDirectory) || !isDirectory {
-                        fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+                        do {
+                            try fileManager.createDirectoryAtPath(outputDirectory, withIntermediateDirectories: true, attributes: nil)
+                        } catch _ {
+                        }
                     }
                     outputDir = outputDirectory
                 }

--- a/Source/SwiftCovFramework/CoverageReporter.swift
+++ b/Source/SwiftCovFramework/CoverageReporter.swift
@@ -65,7 +65,7 @@ public class CoverageReporter {
                         let dyldFallbackLibraryPath = "\(xcodePath)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib"
 
                         var env = [
-                            "SWIFTCOV_FILES": join("\n", files ?? []),
+                            "SWIFTCOV_FILES": (files ?? []).joinWithSeparator("\n"),
                             "SWIFTCOV_SDK_NAME": sdkName,
                             "SWIFTCOV_DYLD_FRAMEWORK_PATH": builtProductsDir,
                             "SWIFTCOV_DYLD_LIBRARY_PATH": builtProductsDir,
@@ -85,7 +85,7 @@ public class CoverageReporter {
 
                             switch bootedDevice {
                             case let .Success(bootedDevice):
-                                if let bootedDevice = bootedDevice.value {
+                                if let bootedDevice = bootedDevice {
                                     env["SWIFTCOV_XPC_SIMULATOR_LAUNCHD_NAME"] = "com.apple.CoreSimulator.SimDevice.\(bootedDevice.UDID).launchd_sim"
                                 }
                             case .Failure:

--- a/Source/SwiftCovFramework/Info.plist
+++ b/Source/SwiftCovFramework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Source/SwiftCovFramework/Shell.swift
+++ b/Source/SwiftCovFramework/Shell.swift
@@ -12,6 +12,8 @@ import Result
 
 public typealias TerminationStatus = Int32
 
+extension TerminationStatus: ErrorType {}
+
 public class Shell {
     private let commandPath: String
     private let arguments: [String]
@@ -62,7 +64,7 @@ public class Shell {
     }
 
     private func launchTask(task: NSTask) -> Result<String, TerminationStatus> {
-        if let fileHandle = task.standardOutput.fileHandleForReading {
+        if let fileHandle = task.standardOutput!.fileHandleForReading {
             fileHandle.readabilityHandler = { fileHandle in
                 if let string = NSString(data: fileHandle.availableData, encoding: NSUTF8StringEncoding) {
                     if self.verbose {
@@ -72,7 +74,7 @@ public class Shell {
                 }
             }
         }
-        if let fileHandle = task.standardError.fileHandleForReading {
+        if let fileHandle = task.standardError!.fileHandleForReading {
             fileHandle.readabilityHandler = { fileHandle in
                 if let string = NSString(data: fileHandle.availableData, encoding: NSUTF8StringEncoding) {
                     if self.verbose {
@@ -105,18 +107,18 @@ public class Shell {
         task.waitUntilExit()
 
         task.terminationHandler = { task in
-            if let fileHandle = task.standardOutput.fileHandleForReading {
+            if let fileHandle = task.standardOutput!.fileHandleForReading {
                 fileHandle.readabilityHandler = nil
             }
-            if let fileHandle = task.standardError.fileHandleForReading {
+            if let fileHandle = task.standardError!.fileHandleForReading {
                 fileHandle.readabilityHandler = nil
             }
         }
 
         if task.terminationStatus == EXIT_SUCCESS {
-            return .success(outputString)
+            return .Success(outputString)
         } else {
-            return .failure(task.terminationStatus)
+            return .Failure(task.terminationStatus)
         }
     }
 }

--- a/Source/SwiftCovFramework/Shell.swift
+++ b/Source/SwiftCovFramework/Shell.swift
@@ -84,19 +84,19 @@ public class Shell {
         }
 
         if verbose {
-            println("Executing command:")
+            print("Executing command:")
             if let environment = environment {
                 for (k, v) in environment {
-                    println("\(k)=\"\(v)\" \\")
+                    print("\(k)=\"\(v)\" \\")
                 }
             }
-            println("\"\(commandPath)\" \\")
-            for (index, argument) in enumerate(arguments) {
-                print("  \"\(argument)\"")
+            print("\"\(commandPath)\" \\")
+            for (index, argument) in arguments.enumerate() {
+                print("  \"\(argument)\"", terminator: "")
                 if index < arguments.count - 1 {
-                    println(" \\")
+                    print(" \\")
                 } else {
-                    println("\n")
+                    print("\n")
                 }
             }
         }

--- a/Source/SwiftCovFramework/SimCtl.swift
+++ b/Source/SwiftCovFramework/SimCtl.swift
@@ -43,8 +43,6 @@ public struct SimCtl {
 
         var mode = Mode.DeviceType
 
-        var target: String?
-        var settings = [String: String]()
         for line in lines {
             switch line {
             case "== Device Types ==":
@@ -89,12 +87,10 @@ public struct DeviceType {
         let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
-                if let match = match as? NSTextCheckingResult {
-                    let name = (line as NSString).substringWithRange(match.rangeAtIndex(1))
-                    let identifier = (line as NSString).substringWithRange(match.rangeAtIndex(2))
+                let name = (line as NSString).substringWithRange(match.rangeAtIndex(1))
+                let identifier = (line as NSString).substringWithRange(match.rangeAtIndex(2))
 
-                    return DeviceType(name: name, identifier: identifier)
-                }
+                return DeviceType(name: name, identifier: identifier)
             }
         }
         return nil
@@ -111,13 +107,11 @@ public struct Runtime {
         let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
-                if let match = match as? NSTextCheckingResult {
-                    let name = (line as NSString).substringWithRange(match.rangeAtIndex(1))
-                    let build = (line as NSString).substringWithRange(match.rangeAtIndex(2))
-                    let identifier = (line as NSString).substringWithRange(match.rangeAtIndex(3))
+                let name = (line as NSString).substringWithRange(match.rangeAtIndex(1))
+                let build = (line as NSString).substringWithRange(match.rangeAtIndex(2))
+                let identifier = (line as NSString).substringWithRange(match.rangeAtIndex(3))
 
-                    return Runtime(name: name, build: build, identifier: identifier)
-                }
+                return Runtime(name: name, build: build, identifier: identifier)
             }
         }
         return nil
@@ -134,13 +128,11 @@ public struct Device {
         let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
-                if let match = match as? NSTextCheckingResult {
-                    let iOSVersion = (line as NSString).substringWithRange(match.rangeAtIndex(1))
-                    let UDID = (line as NSString).substringWithRange(match.rangeAtIndex(2))
-                    let state = (line as NSString).substringWithRange(match.rangeAtIndex(3))
+                let iOSVersion = (line as NSString).substringWithRange(match.rangeAtIndex(1))
+                let UDID = (line as NSString).substringWithRange(match.rangeAtIndex(2))
+                let state = (line as NSString).substringWithRange(match.rangeAtIndex(3))
 
-                    return Device(iOSVersion: iOSVersion, UDID: UDID, booted: state == "Booted")
-                }
+                return Device(iOSVersion: iOSVersion, UDID: UDID, booted: state == "Booted")
             }
         }
         return nil

--- a/Source/SwiftCovFramework/SimCtl.swift
+++ b/Source/SwiftCovFramework/SimCtl.swift
@@ -85,8 +85,8 @@ public struct DeviceType {
     public let identifier: String
 
     internal static func parseLine(line: String) -> DeviceType? {
-        let regex = NSRegularExpression(pattern: "^(.+) \\((.+)\\)$", options: nil, error: nil)!
-        let matches = regex.matchesInString(line, options: nil, range: NSRange(location: 0, length: (line as NSString).length))
+        let regex = try! NSRegularExpression(pattern: "^(.+) \\((.+)\\)$", options: [])
+        let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
                 if let match = match as? NSTextCheckingResult {
@@ -107,8 +107,8 @@ public struct Runtime {
     public let identifier: String
 
     internal static func parseLine(line: String) -> Runtime? {
-        let regex = NSRegularExpression(pattern: "^(.+) \\((.+)\\) \\((.+)\\)$", options: nil, error: nil)!
-        let matches = regex.matchesInString(line, options: nil, range: NSRange(location: 0, length: (line as NSString).length))
+        let regex = try! NSRegularExpression(pattern: "^(.+) \\((.+)\\) \\((.+)\\)$", options: [])
+        let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
                 if let match = match as? NSTextCheckingResult {
@@ -130,8 +130,8 @@ public struct Device {
     public let booted: Bool
 
     internal static func parseLine(line: String) -> Device? {
-        let regex = NSRegularExpression(pattern: "^(.+) \\((.+)\\) \\((.+)\\)$", options: nil, error: nil)!
-        let matches = regex.matchesInString(line, options: nil, range: NSRange(location: 0, length: (line as NSString).length))
+        let regex = try! NSRegularExpression(pattern: "^(.+) \\((.+)\\) \\((.+)\\)$", options: [])
+        let matches = regex.matchesInString(line, options: [], range: NSRange(location: 0, length: (line as NSString).length))
         if matches.count == 1 {
             for match in matches {
                 if let match = match as? NSTextCheckingResult {

--- a/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
+++ b/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
@@ -21,6 +21,7 @@ class CoverageReporterTests: XCTestCase {
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
+        NSFileManager.defaultManager().changeCurrentDirectoryPath((((__FILE__ as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent)
         let xcodebuild = Xcodebuild(arguments: ["test",
                                                 "-project", "./Examples/ExampleFramework/ExampleFramework.xcodeproj",
                                                 "-scheme", "ExampleFramework-iOS",
@@ -64,6 +65,7 @@ class CoverageReporterTests: XCTestCase {
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
+        NSFileManager.defaultManager().changeCurrentDirectoryPath((((__FILE__ as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent)
         let xcodebuild = Xcodebuild(arguments: ["test",
                                                 "-project", "./Examples/ExampleFramework/ExampleFramework.xcodeproj",
                                                 "-scheme", "ExampleFramework-Mac",

--- a/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
+++ b/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
@@ -24,8 +24,11 @@ class CoverageReporterTests: XCTestCase {
     }
 
     func testGenerateCoverageReportIOS() {
-        let temporaryDirectory = NSTemporaryDirectory().stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
-        NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+        let temporaryDirectory = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
+        do {
+            try NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch _ {
+        }
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
@@ -45,12 +48,12 @@ class CoverageReporterTests: XCTestCase {
                 case .Success:
                     Array(zip(reportFilenames, fixtureFilePaths))
                         .map { (reportFilename, fixtureFilePath) -> (String, String) in
-                            return (temporaryDirectory.stringByAppendingPathComponent(reportFilename), fixtureFilePath)
+                            return ((temporaryDirectory as NSString).stringByAppendingPathComponent(reportFilename), fixtureFilePath)
                         }
                         .map { (reportFilePath, fixtureFilePath) in
                             XCTAssertEqual(
-                                dropFirst(split(NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding, error: nil) as! String) { $0 == "\n" }),
-                                dropFirst(split(NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding, error: nil) as! String) { $0 == "\n" }))
+                                ((try! NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst(),
+                                ((try! NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst())
                     }
                 case let .Failure(error):
                     XCTAssertNotEqual(error.value, EXIT_SUCCESS)
@@ -67,8 +70,11 @@ class CoverageReporterTests: XCTestCase {
     }
 
     func testGenerateCoverageReportOSX() {
-        let temporaryDirectory = NSTemporaryDirectory().stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
-        NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil, error: nil)
+        let temporaryDirectory = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
+        do {
+            try NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch _ {
+        }
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
@@ -88,12 +94,12 @@ class CoverageReporterTests: XCTestCase {
                 case .Success:
                     Array(zip(reportFilenames, fixtureFilePaths))
                         .map { (reportFilename, fixtureFilePath) -> (String, String) in
-                            return (temporaryDirectory.stringByAppendingPathComponent(reportFilename), fixtureFilePath)
+                            return ((temporaryDirectory as NSString).stringByAppendingPathComponent(reportFilename), fixtureFilePath)
                         }
                         .map { (reportFilePath, fixtureFilePath) in
                             XCTAssertEqual(
-                                dropFirst(split(NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding, error: nil) as! String) { $0 == "\n" }),
-                                dropFirst(split(NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding, error: nil) as! String) { $0 == "\n" }))
+                                ((try! NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst(),
+                                ((try! NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst())
                     }
                 case let .Failure(error):
                     XCTAssertNotEqual(error.value, EXIT_SUCCESS)

--- a/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
+++ b/Source/SwiftCovFrameworkTests/CoverageReporterTests.swift
@@ -15,20 +15,9 @@ class CoverageReporterTests: XCTestCase {
         return reportFilenames.map { "./Examples/ExampleFramework/results/" + $0 }
     }
 
-    override func setUp() {
-        super.setUp()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-    }
-
     func testGenerateCoverageReportIOS() {
         let temporaryDirectory = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
-        do {
-            try NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
-        } catch _ {
-        }
+        _ = try? NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
@@ -40,7 +29,7 @@ class CoverageReporterTests: XCTestCase {
                                                 "-derivedDataPath", temporaryDirectory])
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):
-            let buildSettings = BuildSettings(output: output.value)
+            let buildSettings = BuildSettings(output: output)
 
             switch xcodebuild.buildExecutable() {
             case .Success:
@@ -50,31 +39,28 @@ class CoverageReporterTests: XCTestCase {
                         .map { (reportFilename, fixtureFilePath) -> (String, String) in
                             return ((temporaryDirectory as NSString).stringByAppendingPathComponent(reportFilename), fixtureFilePath)
                         }
-                        .map { (reportFilePath, fixtureFilePath) in
+                        .forEach { (reportFilePath, fixtureFilePath) in
                             XCTAssertEqual(
                                 ((try! NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst(),
                                 ((try! NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst())
                     }
                 case let .Failure(error):
-                    XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                    XCTAssertNotEqual(error, EXIT_SUCCESS)
                     XCTFail("Execution failure")
                 }
             case let .Failure(error):
-                XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                XCTAssertNotEqual(error, EXIT_SUCCESS)
                 XCTFail("Execution failure")
             }
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
 
     func testGenerateCoverageReportOSX() {
         let temporaryDirectory = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(NSProcessInfo().globallyUniqueString)
-        do {
-            try NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
-        } catch _ {
-        }
+        _ = try? NSFileManager().createDirectoryAtPath(temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
 
         let reporter = CoverageReporter(outputDirectory: temporaryDirectory, threshold: 0)
 
@@ -86,7 +72,7 @@ class CoverageReporterTests: XCTestCase {
                                                 "-derivedDataPath", temporaryDirectory])
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):
-            let buildSettings = BuildSettings(output: output.value)
+            let buildSettings = BuildSettings(output: output)
             
             switch xcodebuild.buildExecutable() {
             case .Success:
@@ -96,21 +82,21 @@ class CoverageReporterTests: XCTestCase {
                         .map { (reportFilename, fixtureFilePath) -> (String, String) in
                             return ((temporaryDirectory as NSString).stringByAppendingPathComponent(reportFilename), fixtureFilePath)
                         }
-                        .map { (reportFilePath, fixtureFilePath) in
+                        .forEach { (reportFilePath, fixtureFilePath) in
                             XCTAssertEqual(
                                 ((try! NSString(contentsOfFile: reportFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst(),
                                 ((try! NSString(contentsOfFile: fixtureFilePath, encoding: NSUTF8StringEncoding)) as String).characters.split { $0 == "\n" }.map { String($0) }.dropFirst())
                     }
                 case let .Failure(error):
-                    XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                    XCTAssertNotEqual(error, EXIT_SUCCESS)
                     XCTFail("Execution failure")
                 }
             case let .Failure(error):
-                XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+                XCTAssertNotEqual(error, EXIT_SUCCESS)
                 XCTFail("Execution failure")
             }
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }

--- a/Source/SwiftCovFrameworkTests/Info.plist
+++ b/Source/SwiftCovFrameworkTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Source/SwiftCovFrameworkTests/ShellTests.swift
+++ b/Source/SwiftCovFrameworkTests/ShellTests.swift
@@ -10,22 +10,13 @@ import XCTest
 import SwiftCovFramework
 
 class ShellTests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
-
     func testCommand() {
         let command = Shell(commandPath: "/bin/echo")
         switch command.output() {
         case let .Success(output):
-            XCTAssertEqual(output.value, "\n")
+            XCTAssertEqual(output, "\n")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -34,9 +25,9 @@ class ShellTests: XCTestCase {
         let command = Shell(commandPath: "/bin/echo", arguments: ["foo"])
         switch command.output() {
         case let .Success(output):
-            XCTAssertEqual(output.value, "foo\n")
+            XCTAssertEqual(output, "foo\n")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -45,9 +36,9 @@ class ShellTests: XCTestCase {
         let command = Shell(commandPath: "/bin/echo", arguments: ["foo", "bar"])
         switch command.output() {
         case let .Success(output):
-            XCTAssertEqual(output.value, "foo bar\n")
+            XCTAssertEqual(output, "foo bar\n")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -56,9 +47,9 @@ class ShellTests: XCTestCase {
         let command = Shell(commandPath: "/bin/echo", arguments: ["-n", "foo"])
         switch command.output() {
         case let .Success(output):
-            XCTAssertEqual(output.value, "foo")
+            XCTAssertEqual(output, "foo")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -67,9 +58,9 @@ class ShellTests: XCTestCase {
         let command = Shell(commandPath: "/bin/ls", workingDirectoryPath: "./Carthage")
         switch command.output() {
         case let .Success(output):
-            XCTAssertEqual(output.value, "Checkouts\n")
+            XCTAssertEqual(output, "Checkouts\n")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -77,10 +68,10 @@ class ShellTests: XCTestCase {
     func testCommandWithIllegalOption() {
         let command = Shell(commandPath: "/bin/ls", arguments: ["-j"])
         switch command.output() {
-        case let .Success(output):
+        case .Success(_):
             XCTFail("Must be fail")
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
         }
     }
 

--- a/Source/SwiftCovFrameworkTests/ShellTests.swift
+++ b/Source/SwiftCovFrameworkTests/ShellTests.swift
@@ -55,6 +55,7 @@ class ShellTests: XCTestCase {
     }
 
     func testCommandWithWorkingDirectoryPath() {
+        NSFileManager.defaultManager().changeCurrentDirectoryPath((((__FILE__ as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent)
         let command = Shell(commandPath: "/bin/ls", workingDirectoryPath: "./Carthage")
         switch command.output() {
         case let .Success(output):

--- a/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
+++ b/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
@@ -10,15 +10,6 @@ import XCTest
 import SwiftCovFramework
 
 class XcodebuildTests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-    }
-
     func testBuildSettings() {
         let xcodebuild = Xcodebuild(arguments: ["test",
                                                 "-scheme", "SwiftCovFramework",
@@ -27,7 +18,7 @@ class XcodebuildTests: XCTestCase {
 
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):
-            let buildSettings = BuildSettings(output: output.value)
+            let buildSettings = BuildSettings(output: output)
 
             let executable = buildSettings.executable
             XCTAssertEqual(executable.name, "SwiftCovFramework")
@@ -79,7 +70,7 @@ class XcodebuildTests: XCTestCase {
                 }
             }
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -94,7 +85,7 @@ class XcodebuildTests: XCTestCase {
 
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):
-            let buildSettings = BuildSettings(output: output.value)
+            let buildSettings = BuildSettings(output: output)
 
             let executable = buildSettings.executable
             XCTAssertEqual(executable.name, "SwiftCovFramework")
@@ -119,7 +110,7 @@ class XcodebuildTests: XCTestCase {
                 XCTFail("Failed to load build settings: SRCROOT")
             }
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }
@@ -134,7 +125,7 @@ class XcodebuildTests: XCTestCase {
 
         switch xcodebuild.showBuildSettings() {
         case let .Success(output):
-            let buildSettings = BuildSettings(output: output.value)
+            let buildSettings = BuildSettings(output: output)
 
             let executable = buildSettings.executable
             XCTAssertEqual(executable.name, "SwiftCovFramework")
@@ -160,14 +151,14 @@ class XcodebuildTests: XCTestCase {
             }
             if let objroot = executable.buildSettings["OBJROOT"] {
                 XCTAssertEqual(objroot,
-                    NSFileManager().currentDirectoryPath
-                    .stringByAppendingPathComponent("build")
+                    ((NSFileManager().currentDirectoryPath as NSString)
+                    .stringByAppendingPathComponent("build") as NSString)
                     .stringByAppendingPathComponent("Build/Intermediates"))
             } else {
                 XCTFail("Failed to load build settings: BUILD_DIR")
             }
         case let .Failure(error):
-            XCTAssertNotEqual(error.value, EXIT_SUCCESS)
+            XCTAssertNotEqual(error, EXIT_SUCCESS)
             XCTFail("Execution failure")
         }
     }

--- a/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
+++ b/Source/SwiftCovFrameworkTests/XcodebuildTests.swift
@@ -11,6 +11,7 @@ import SwiftCovFramework
 
 class XcodebuildTests: XCTestCase {
     func testBuildSettings() {
+        NSFileManager.defaultManager().changeCurrentDirectoryPath((((__FILE__ as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent)
         let xcodebuild = Xcodebuild(arguments: ["test",
                                                 "-scheme", "SwiftCovFramework",
                                                 "-configuration", "Debug",
@@ -116,6 +117,7 @@ class XcodebuildTests: XCTestCase {
     }
 
     func testAddArgument() {
+        NSFileManager.defaultManager().changeCurrentDirectoryPath((((__FILE__ as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent as NSString).stringByDeletingLastPathComponent)
         var xcodebuild = Xcodebuild(arguments: ["test",
                                                 "-scheme", "SwiftCovFramework",
                                                 "-configuration", "Debug",

--- a/Source/swiftcov/Components.plist
+++ b/Source/swiftcov/Components.plist
@@ -21,12 +21,6 @@
 				<key>RootRelativeBundlePath</key>
 				<string>Library/Frameworks/SwiftCovFramework.framework/Versions/A/Frameworks/Result.framework</string>
 			</dict>
-			<dict>
-				<key>BundleOverwriteAction</key>
-				<string></string>
-				<key>RootRelativeBundlePath</key>
-				<string>Library/Frameworks/SwiftCovFramework.framework/Versions/A/Frameworks/Box.framework</string>
-			</dict>
 		</array>
 		<key>RootRelativeBundlePath</key>
 		<string>Library/Frameworks/SwiftCovFramework.framework</string>

--- a/Source/swiftcov/Errors.swift
+++ b/Source/swiftcov/Errors.swift
@@ -9,7 +9,7 @@
 import Commandant
 
 /// Possible errors within SwiftCov.
-enum SwiftCovError: CustomStringConvertible {
+enum SwiftCovError: ErrorType, CustomStringConvertible {
     /// One or more argument was invalid.
     case InvalidArgument(description: String)
 
@@ -29,13 +29,13 @@ enum SwiftCovError: CustomStringConvertible {
         switch self {
         case let .InvalidArgument(description):
             return description
-        case let .MissingBuildSetting(description):
+        case .MissingBuildSetting(_):
             return "`xcodebuild` did not return a build setting that we needed."
         case let .ReadFailed(path):
             return "Failed to read file at '\(path)'."
-        case let .GenerateFailed:
+        case .GenerateFailed:
             return "Failed to generate test code coverage files."
-        case let .TaskError:
+        case .TaskError:
             return "A shell task exited unsuccessfully."
         }
     }

--- a/Source/swiftcov/Errors.swift
+++ b/Source/swiftcov/Errors.swift
@@ -10,7 +10,7 @@ import Commandant
 import Box
 
 /// Possible errors within SwiftCov.
-enum SwiftCovError: Printable {
+enum SwiftCovError: CustomStringConvertible {
     /// One or more argument was invalid.
     case InvalidArgument(description: String)
 

--- a/Source/swiftcov/Errors.swift
+++ b/Source/swiftcov/Errors.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Box
 
 /// Possible errors within SwiftCov.
 enum SwiftCovError: CustomStringConvertible {
@@ -43,5 +42,5 @@ enum SwiftCovError: CustomStringConvertible {
 }
 
 func toCommandantError(swiftCovError: SwiftCovError) -> CommandantError<SwiftCovError> {
-    return .CommandError(Box(swiftCovError))
+    return .CommandError(swiftCovError)
 }

--- a/Source/swiftcov/Generate.swift
+++ b/Source/swiftcov/Generate.swift
@@ -1,103 +1,100 @@
-////
-////  GenerateCommand.swift
-////  SwiftCov
-////
-////  Created by JP Simard on 2015-05-20.
-////  Copyright (c) 2015 Realm. All rights reserved.
-////
 //
-//import Commandant
-//import Result
-//import SwiftCovFramework
+//  GenerateCommand.swift
+//  SwiftCov
 //
-//extension NSString {
-//    /**
-//    Returns self represented as an absolute path.
+//  Created by JP Simard on 2015-05-20.
+//  Copyright (c) 2015 Realm. All rights reserved.
 //
-//    - parameter rootDirectory: Absolute parent path if not already an absolute path.
-//    */
-//    public func absolutePathRepresentation(rootDirectory: String = NSFileManager.defaultManager().currentDirectoryPath) -> String {
-//        if absolutePath {
-//            return self as String
-//        }
-//        return NSString.pathWithComponents([rootDirectory, self]).stringByStandardizingPath
-//    }
-//}
-//
-//struct GenerateCommand: CommandType {
-//    typealias ClientError = SwiftCovError
-//    let verb = "generate"
-//    let function = "Generate test code coverage files for your Swift tests"
-//
-//    func run(mode: CommandMode) -> Result<(), CommandantError<SwiftCovError>> {
-//        return GenerateOptions.evaluate(mode).flatMap { options in
-//            let arguments = Process.arguments
-//            if arguments.count < 4 {
-//                return .failure(.UsageError(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
-//            }
-//            let requiredArguments = [
-//                "xcodebuild",
-//                "test",
-//                "-configuration",
-//                "-sdk"
-//            ]
-//            for argument in requiredArguments {
-//                if find(arguments, argument) == nil {
-//                    return .failure(.UsageError(description: "'\(argument)' argument required"))
-//                }
-//            }
-//
-//            println("Generate test code coverage files")
-//            println("Loading build settings...")
-//
-//            let doubleDashSplit = split(arguments, allowEmptySlices: true) { $0 == "--" }
-//            let afterDoubleDash = flatMap(count(doubleDashSplit) == 2 ? true : nil) { _ in Array(doubleDashSplit[1]) }
-//            let files = map(afterDoubleDash) { nonOptionalAfterDoubleDash in
-//                return map(nonOptionalAfterDoubleDash) {
-//                    ($0 as NSString).absolutePathRepresentation()
-//                }
-//            }
-//            let beforeDoubleDash = Array(doubleDashSplit[0])
-//            let xcodeBuildArguments = Array(split(beforeDoubleDash, allowEmptySlices: true) { $0 == "xcodebuild" }[1])
-//
-//            var xcodebuild = Xcodebuild(arguments: xcodeBuildArguments, verbose: options.debug)
-//            let result = xcodebuild.showBuildSettings()
-//                .map { BuildSettings(output: $0) }
-//                .flatMap { buildSettings -> Result<BuildSettings, TerminationStatus> in
-//                    println("Building target...")
-//                    return xcodebuild.buildExecutable().flatMap { _ in
-//                        return .success(buildSettings)
-//                    }
-//                }
-//                .flatMap { buildSettings -> Result<String, TerminationStatus> in
-//                    println("Generating code coverage...")
-//                    let coverageReporter = CoverageReporter(outputDirectory: options.output, threshold: options.threshold, verbose: options.debug, files: files)
-//                    return coverageReporter.runCoverageReport(buildSettings: buildSettings)
-//            }
-//
-//            switch result {
-//            case .Success:
-//                return .success()
-//            case let .Failure(error):
-//                return .failure(toCommandantError(.GenerateFailed))
-//            }
-//        }
-//    }
-//}
-//
-//struct GenerateOptions: OptionsType {
-//    let output: String
-//    let threshold: Int
-//    let debug: Bool
-//
-//    static func create(output: String)(threshold: Int)(debug: Bool) -> GenerateOptions {
-//        return self.init(output: output, threshold: threshold, debug: debug)
-//    }
-//
-//    static func evaluate(m: CommandMode) -> Result<GenerateOptions, CommandantError<SwiftCovError>> {
-//        return create
-//            <*> m <| Option(key: "output", defaultValue: "", usage: "Folder to output the coverage files to")
-//            <*> m <| Option(key: "threshold", defaultValue: 1, usage: "Threshold value of max hit count (for performance)")
-//            <*> m <| Option(key: "debug", defaultValue: false, usage: "Output very verbose progress messages")
-//    }
-//}
+
+import Commandant
+import Result
+import SwiftCovFramework
+
+extension NSString {
+    /**
+    Returns self represented as an absolute path.
+
+    - parameter rootDirectory: Absolute parent path if not already an absolute path.
+    */
+    public func absolutePathRepresentation(rootDirectory: String = NSFileManager.defaultManager().currentDirectoryPath) -> String {
+        if absolutePath {
+            return self as String
+        }
+        return (NSString.pathWithComponents([rootDirectory, self as String]) as NSString).stringByStandardizingPath
+    }
+}
+
+struct GenerateCommand: CommandType {
+    let verb = "generate"
+    let function = "Generate test code coverage files for your Swift tests"
+
+    func run(options: GenerateOptions) -> Result<(), CommandantError<SwiftCovError>> {
+        let arguments = Process.arguments
+        if arguments.count < 4 {
+            return .Failure(.UsageError(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
+        }
+        let requiredArguments = [
+            "xcodebuild",
+            "test",
+            "-configuration",
+            "-sdk"
+        ]
+        for argument in requiredArguments {
+            if arguments.indexOf(argument) == nil {
+                return .Failure(.UsageError(description: "'\(argument)' argument required"))
+            }
+        }
+
+        print("Generate test code coverage files")
+        print("Loading build settings...")
+
+        let doubleDashSplit = arguments.split("--", maxSplit: Int.max, allowEmptySlices: true)
+        let afterDoubleDash = (doubleDashSplit.count == 2 ? true : Optional<Bool>.None).flatMap { _ in Array(doubleDashSplit[1]) }
+        let files = afterDoubleDash.map { nonOptionalAfterDoubleDash in
+            return nonOptionalAfterDoubleDash.map {
+                ($0 as NSString).absolutePathRepresentation()
+            }
+        }
+        let beforeDoubleDash = Array(doubleDashSplit[0])
+        let xcodeBuildArguments = Array(beforeDoubleDash.split("xcodebuild", maxSplit: Int.max, allowEmptySlices: true)[1])
+
+        let xcodebuild = Xcodebuild(arguments: xcodeBuildArguments, verbose: options.debug)
+        let result = xcodebuild.showBuildSettings()
+            .map { BuildSettings(output: $0) }
+            .flatMap { buildSettings -> Result<BuildSettings, TerminationStatus> in
+                print("Building target...")
+                return xcodebuild.buildExecutable().flatMap { _ in
+                    return .Success(buildSettings)
+                }
+            }
+            .flatMap { buildSettings -> Result<String, TerminationStatus> in
+                print("Generating code coverage...")
+                let coverageReporter = CoverageReporter(outputDirectory: options.output, threshold: options.threshold, verbose: options.debug, files: files)
+                return coverageReporter.runCoverageReport(buildSettings: buildSettings)
+        }
+
+        switch result {
+        case .Success:
+            return .Success()
+        case .Failure(_):
+            return .Failure(toCommandantError(.GenerateFailed))
+        }
+    }
+}
+
+struct GenerateOptions: OptionsType {
+    let output: String
+    let threshold: Int
+    let debug: Bool
+
+    static func create(output: String)(threshold: Int)(debug: Bool) -> GenerateOptions {
+        return self.init(output: output, threshold: threshold, debug: debug)
+    }
+
+    static func evaluate(m: CommandMode) -> Result<GenerateOptions, CommandantError<SwiftCovError>> {
+        return create
+            <*> m <| Option(key: "output", defaultValue: "", usage: "Folder to output the coverage files to")
+            <*> m <| Option(key: "threshold", defaultValue: 1, usage: "Threshold value of max hit count (for performance)")
+            <*> m <| Option(key: "debug", defaultValue: false, usage: "Output very verbose progress messages")
+    }
+}

--- a/Source/swiftcov/Generate.swift
+++ b/Source/swiftcov/Generate.swift
@@ -28,10 +28,10 @@ struct GenerateCommand: CommandType {
     let verb = "generate"
     let function = "Generate test code coverage files for your Swift tests"
 
-    func run(options: GenerateOptions) -> Result<(), CommandantError<SwiftCovError>> {
+    func run(options: GenerateOptions) -> Result<(), SwiftCovError> {
         let arguments = Process.arguments
         if arguments.count < 4 {
-            return .Failure(.UsageError(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
+            return .Failure(.InvalidArgument(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
         }
         let requiredArguments = [
             "xcodebuild",
@@ -41,7 +41,7 @@ struct GenerateCommand: CommandType {
         ]
         for argument in requiredArguments {
             if arguments.indexOf(argument) == nil {
-                return .Failure(.UsageError(description: "'\(argument)' argument required"))
+                return .Failure(.InvalidArgument(description: "'\(argument)' argument required"))
             }
         }
 
@@ -77,7 +77,7 @@ struct GenerateCommand: CommandType {
         case .Success:
             return .Success()
         case .Failure(_):
-            return .Failure(toCommandantError(.GenerateFailed))
+            return .Failure(.GenerateFailed)
         }
     }
 }

--- a/Source/swiftcov/Generate.swift
+++ b/Source/swiftcov/Generate.swift
@@ -14,7 +14,7 @@ extension NSString {
     /**
     Returns self represented as an absolute path.
 
-    :param: rootDirectory Absolute parent path if not already an absolute path.
+    - parameter rootDirectory: Absolute parent path if not already an absolute path.
     */
     public func absolutePathRepresentation(rootDirectory: String = NSFileManager.defaultManager().currentDirectoryPath) -> String {
         if absolutePath {
@@ -91,7 +91,7 @@ struct GenerateOptions: OptionsType {
     let debug: Bool
 
     static func create(output: String)(threshold: Int)(debug: Bool) -> GenerateOptions {
-        return self(output: output, threshold: threshold, debug: debug)
+        return self.init(output: output, threshold: threshold, debug: debug)
     }
 
     static func evaluate(m: CommandMode) -> Result<GenerateOptions, CommandantError<SwiftCovError>> {

--- a/Source/swiftcov/Generate.swift
+++ b/Source/swiftcov/Generate.swift
@@ -1,103 +1,103 @@
+////
+////  GenerateCommand.swift
+////  SwiftCov
+////
+////  Created by JP Simard on 2015-05-20.
+////  Copyright (c) 2015 Realm. All rights reserved.
+////
 //
-//  GenerateCommand.swift
-//  SwiftCov
+//import Commandant
+//import Result
+//import SwiftCovFramework
 //
-//  Created by JP Simard on 2015-05-20.
-//  Copyright (c) 2015 Realm. All rights reserved.
+//extension NSString {
+//    /**
+//    Returns self represented as an absolute path.
 //
-
-import Commandant
-import Result
-import SwiftCovFramework
-
-extension NSString {
-    /**
-    Returns self represented as an absolute path.
-
-    - parameter rootDirectory: Absolute parent path if not already an absolute path.
-    */
-    public func absolutePathRepresentation(rootDirectory: String = NSFileManager.defaultManager().currentDirectoryPath) -> String {
-        if absolutePath {
-            return self as String
-        }
-        return NSString.pathWithComponents([rootDirectory, self]).stringByStandardizingPath
-    }
-}
-
-struct GenerateCommand: CommandType {
-    typealias ClientError = SwiftCovError
-    let verb = "generate"
-    let function = "Generate test code coverage files for your Swift tests"
-
-    func run(mode: CommandMode) -> Result<(), CommandantError<SwiftCovError>> {
-        return GenerateOptions.evaluate(mode).flatMap { options in
-            let arguments = Process.arguments
-            if arguments.count < 4 {
-                return .failure(.UsageError(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
-            }
-            let requiredArguments = [
-                "xcodebuild",
-                "test",
-                "-configuration",
-                "-sdk"
-            ]
-            for argument in requiredArguments {
-                if find(arguments, argument) == nil {
-                    return .failure(.UsageError(description: "'\(argument)' argument required"))
-                }
-            }
-
-            println("Generate test code coverage files")
-            println("Loading build settings...")
-
-            let doubleDashSplit = split(arguments, allowEmptySlices: true) { $0 == "--" }
-            let afterDoubleDash = flatMap(count(doubleDashSplit) == 2 ? true : nil) { _ in Array(doubleDashSplit[1]) }
-            let files = map(afterDoubleDash) { nonOptionalAfterDoubleDash in
-                return map(nonOptionalAfterDoubleDash) {
-                    ($0 as NSString).absolutePathRepresentation()
-                }
-            }
-            let beforeDoubleDash = Array(doubleDashSplit[0])
-            let xcodeBuildArguments = Array(split(beforeDoubleDash, allowEmptySlices: true) { $0 == "xcodebuild" }[1])
-
-            var xcodebuild = Xcodebuild(arguments: xcodeBuildArguments, verbose: options.debug)
-            let result = xcodebuild.showBuildSettings()
-                .map { BuildSettings(output: $0) }
-                .flatMap { buildSettings -> Result<BuildSettings, TerminationStatus> in
-                    println("Building target...")
-                    return xcodebuild.buildExecutable().flatMap { _ in
-                        return .success(buildSettings)
-                    }
-                }
-                .flatMap { buildSettings -> Result<String, TerminationStatus> in
-                    println("Generating code coverage...")
-                    let coverageReporter = CoverageReporter(outputDirectory: options.output, threshold: options.threshold, verbose: options.debug, files: files)
-                    return coverageReporter.runCoverageReport(buildSettings: buildSettings)
-            }
-
-            switch result {
-            case .Success:
-                return .success()
-            case let .Failure(error):
-                return .failure(toCommandantError(.GenerateFailed))
-            }
-        }
-    }
-}
-
-struct GenerateOptions: OptionsType {
-    let output: String
-    let threshold: Int
-    let debug: Bool
-
-    static func create(output: String)(threshold: Int)(debug: Bool) -> GenerateOptions {
-        return self.init(output: output, threshold: threshold, debug: debug)
-    }
-
-    static func evaluate(m: CommandMode) -> Result<GenerateOptions, CommandantError<SwiftCovError>> {
-        return create
-            <*> m <| Option(key: "output", defaultValue: "", usage: "Folder to output the coverage files to")
-            <*> m <| Option(key: "threshold", defaultValue: 1, usage: "Threshold value of max hit count (for performance)")
-            <*> m <| Option(key: "debug", defaultValue: false, usage: "Output very verbose progress messages")
-    }
-}
+//    - parameter rootDirectory: Absolute parent path if not already an absolute path.
+//    */
+//    public func absolutePathRepresentation(rootDirectory: String = NSFileManager.defaultManager().currentDirectoryPath) -> String {
+//        if absolutePath {
+//            return self as String
+//        }
+//        return NSString.pathWithComponents([rootDirectory, self]).stringByStandardizingPath
+//    }
+//}
+//
+//struct GenerateCommand: CommandType {
+//    typealias ClientError = SwiftCovError
+//    let verb = "generate"
+//    let function = "Generate test code coverage files for your Swift tests"
+//
+//    func run(mode: CommandMode) -> Result<(), CommandantError<SwiftCovError>> {
+//        return GenerateOptions.evaluate(mode).flatMap { options in
+//            let arguments = Process.arguments
+//            if arguments.count < 4 {
+//                return .failure(.UsageError(description: "Usage: swiftcov generate [swiftcov options] xcodebuild [xcodebuild options] (-- [swift files])"))
+//            }
+//            let requiredArguments = [
+//                "xcodebuild",
+//                "test",
+//                "-configuration",
+//                "-sdk"
+//            ]
+//            for argument in requiredArguments {
+//                if find(arguments, argument) == nil {
+//                    return .failure(.UsageError(description: "'\(argument)' argument required"))
+//                }
+//            }
+//
+//            println("Generate test code coverage files")
+//            println("Loading build settings...")
+//
+//            let doubleDashSplit = split(arguments, allowEmptySlices: true) { $0 == "--" }
+//            let afterDoubleDash = flatMap(count(doubleDashSplit) == 2 ? true : nil) { _ in Array(doubleDashSplit[1]) }
+//            let files = map(afterDoubleDash) { nonOptionalAfterDoubleDash in
+//                return map(nonOptionalAfterDoubleDash) {
+//                    ($0 as NSString).absolutePathRepresentation()
+//                }
+//            }
+//            let beforeDoubleDash = Array(doubleDashSplit[0])
+//            let xcodeBuildArguments = Array(split(beforeDoubleDash, allowEmptySlices: true) { $0 == "xcodebuild" }[1])
+//
+//            var xcodebuild = Xcodebuild(arguments: xcodeBuildArguments, verbose: options.debug)
+//            let result = xcodebuild.showBuildSettings()
+//                .map { BuildSettings(output: $0) }
+//                .flatMap { buildSettings -> Result<BuildSettings, TerminationStatus> in
+//                    println("Building target...")
+//                    return xcodebuild.buildExecutable().flatMap { _ in
+//                        return .success(buildSettings)
+//                    }
+//                }
+//                .flatMap { buildSettings -> Result<String, TerminationStatus> in
+//                    println("Generating code coverage...")
+//                    let coverageReporter = CoverageReporter(outputDirectory: options.output, threshold: options.threshold, verbose: options.debug, files: files)
+//                    return coverageReporter.runCoverageReport(buildSettings: buildSettings)
+//            }
+//
+//            switch result {
+//            case .Success:
+//                return .success()
+//            case let .Failure(error):
+//                return .failure(toCommandantError(.GenerateFailed))
+//            }
+//        }
+//    }
+//}
+//
+//struct GenerateOptions: OptionsType {
+//    let output: String
+//    let threshold: Int
+//    let debug: Bool
+//
+//    static func create(output: String)(threshold: Int)(debug: Bool) -> GenerateOptions {
+//        return self.init(output: output, threshold: threshold, debug: debug)
+//    }
+//
+//    static func evaluate(m: CommandMode) -> Result<GenerateOptions, CommandantError<SwiftCovError>> {
+//        return create
+//            <*> m <| Option(key: "output", defaultValue: "", usage: "Folder to output the coverage files to")
+//            <*> m <| Option(key: "threshold", defaultValue: 1, usage: "Threshold value of max hit count (for performance)")
+//            <*> m <| Option(key: "debug", defaultValue: false, usage: "Output very verbose progress messages")
+//    }
+//}

--- a/Source/swiftcov/Info.plist
+++ b/Source/swiftcov/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Source/swiftcov/Version.swift
+++ b/Source/swiftcov/Version.swift
@@ -14,7 +14,7 @@ struct VersionCommand: CommandType {
     let verb = "version"
     let function = "Display the current version of SwiftLint"
 
-    func run(options: NoOptions<CommandantError<()>>) -> Result<(), CommandantError<()>> {
+    func run(options: NoOptions<SwiftCovError>) -> Result<(), SwiftCovError> {
         let version = NSBundle(identifier: SwiftCovFrameworkBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         print(version!)
         return .Success()

--- a/Source/swiftcov/Version.swift
+++ b/Source/swiftcov/Version.swift
@@ -11,19 +11,12 @@ import Result
 import let SwiftCovFramework.SwiftCovFrameworkBundleIdentifier
 
 struct VersionCommand: CommandType {
-    typealias ClientError = SwiftCovError
     let verb = "version"
-    let function = "Display the current version of SwiftCov"
+    let function = "Display the current version of SwiftLint"
 
-    func run(mode: CommandMode) -> Result<(), CommandantError<SwiftCovError>> {
-        switch mode {
-        case .Arguments:
-            let version = NSBundle(identifier: SwiftCovFrameworkBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
-            println(version!)
-
-        default:
-            break
-        }
-        return .success(())
+    func run(options: NoOptions<CommandantError<()>>) -> Result<(), CommandantError<()>> {
+        let version = NSBundle(identifier: SwiftCovFrameworkBundleIdentifier)?.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        print(version!)
+        return .Success()
     }
 }

--- a/Source/swiftcov/main.swift
+++ b/Source/swiftcov/main.swift
@@ -8,8 +8,8 @@
 
 import Commandant
 
-let registry = CommandRegistry<SwiftCovError>()
-registry.register(GenerateCommand())
+let registry = CommandRegistry<CommandantError<()>>()
+//registry.register(GenerateCommand())
 registry.register(VersionCommand())
 
 let helpCommand = HelpCommand(registry: registry)

--- a/Source/swiftcov/main.swift
+++ b/Source/swiftcov/main.swift
@@ -8,8 +8,8 @@
 
 import Commandant
 
-let registry = CommandRegistry<CommandantError<()>>()
-//registry.register(GenerateCommand())
+let registry = CommandRegistry<SwiftCovError>()
+registry.register(GenerateCommand())
 registry.register(VersionCommand())
 
 let helpCommand = HelpCommand(registry: registry)

--- a/SwiftCov.xcworkspace/contents.xcworkspacedata
+++ b/SwiftCov.xcworkspace/contents.xcworkspacedata
@@ -10,7 +10,4 @@
    <FileRef
       location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:Carthage/Checkouts/Box/Box.xcodeproj">
-   </FileRef>
 </Workspace>

--- a/SwiftCov.xcworkspace/xcshareddata/SwiftCov.xcscmblueprint
+++ b/SwiftCov.xcworkspace/xcshareddata/SwiftCov.xcscmblueprint
@@ -1,0 +1,44 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "F279C6E8AF4FC2EB4BEB1AFF111FE1407D8830AA",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "E084C86B03F81D63323C9E7510697EA528A758C7" : 0,
+    "F279C6E8AF4FC2EB4BEB1AFF111FE1407D8830AA" : 0,
+    "D23C0CEAADB77074FDA4459000068A7940EB7AD0" : 0,
+    "956D2B21DD155C49504BB67697A67F7C5351A353" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "5F862A64-9A71-4CAA-B8B9-050C505D3205",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "E084C86B03F81D63323C9E7510697EA528A758C7" : "SwiftCov\/Carthage\/Checkouts\/Commandant\/Carthage\/Checkouts\/xcconfigs\/",
+    "F279C6E8AF4FC2EB4BEB1AFF111FE1407D8830AA" : "SwiftCov\/",
+    "D23C0CEAADB77074FDA4459000068A7940EB7AD0" : "SwiftCov\/Carthage\/Checkouts\/Commandant\/",
+    "956D2B21DD155C49504BB67697A67F7C5351A353" : "SwiftCov\/Carthage\/Checkouts\/Result\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "SwiftCov",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "SwiftCov.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/antitypical\/Result.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "956D2B21DD155C49504BB67697A67F7C5351A353"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/Carthage\/Commandant.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "D23C0CEAADB77074FDA4459000068A7940EB7AD0"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/jspahrsummers\/xcconfigs.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "E084C86B03F81D63323C9E7510697EA528A758C7"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:realm\/SwiftCov.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "F279C6E8AF4FC2EB4BEB1AFF111FE1407D8830AA"
+    }
+  ]
+}

--- a/swiftcov.xcodeproj/project.pbxproj
+++ b/swiftcov.xcodeproj/project.pbxproj
@@ -22,10 +22,8 @@
 		D0E7B65319E9C6AD00EDBA4D /* SwiftCovFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SwiftCovFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
 		E83A0B351A5D382B0041A60A /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* Version.swift */; };
-		E8996A241B0CA04000CFEC14 /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8996A231B0CA04000CFEC14 /* Box.framework */; };
 		E8996A261B0CA04300CFEC14 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8996A251B0CA04300CFEC14 /* Result.framework */; };
 		E8996A271B0CA06600CFEC14 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8996A251B0CA04300CFEC14 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E8996A281B0CA06600CFEC14 /* Box.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8996A231B0CA04000CFEC14 /* Box.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E8D86D851A688EF20063E8E9 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D86D841A688EF20063E8E9 /* Errors.swift */; };
 		E8DC55061B0C9CF900A694F5 /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8DC55051B0C9CF900A694F5 /* Commandant.framework */; };
 		E8DC55071B0C9D3300A694F5 /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8DC55051B0C9CF900A694F5 /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -57,7 +55,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				E8996A271B0CA06600CFEC14 /* Result.framework in Copy Frameworks */,
-				E8996A281B0CA06600CFEC14 /* Box.framework in Copy Frameworks */,
 				E8DC55071B0C9D3300A694F5 /* Commandant.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -115,7 +112,6 @@
 		D0E7B63219E9C64500EDBA4D /* swiftcov.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swiftcov.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0E7B65819E9CA0800EDBA4D /* swiftcov */ = {isa = PBXFileReference; lastKnownFileType = text; path = swiftcov; sourceTree = BUILT_PRODUCTS_DIR; };
 		E83A0B341A5D382B0041A60A /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
-		E8996A231B0CA04000CFEC14 /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Box.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8996A251B0CA04300CFEC14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8D86D841A688EF20063E8E9 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		E8DC55051B0C9CF900A694F5 /* Commandant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -128,7 +124,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E8996A261B0CA04300CFEC14 /* Result.framework in Frameworks */,
-				E8996A241B0CA04000CFEC14 /* Box.framework in Frameworks */,
 				E8DC55061B0C9CF900A694F5 /* Commandant.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -283,7 +278,6 @@
 			children = (
 				E8DC55051B0C9CF900A694F5 /* Commandant.framework */,
 				E8996A251B0CA04300CFEC14 /* Result.framework */,
-				E8996A231B0CA04000CFEC14 /* Box.framework */,
 				D0D1217019E87B05005E4BAA /* Info.plist */,
 			);
 			name = "Supporting Files";

--- a/swiftcov.xcodeproj/project.pbxproj
+++ b/swiftcov.xcodeproj/project.pbxproj
@@ -543,11 +543,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/$(CONFIGURATION)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SwiftCovFramework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib";
@@ -579,11 +575,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/$(CONFIGURATION)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SwiftCovFramework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib";
@@ -652,11 +644,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/$(CONFIGURATION)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SwiftCovFramework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib";
@@ -711,11 +699,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/$(CONFIGURATION)",
-					"$(PROJECT_DIR)/build/DerivedData/SwiftCov/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SwiftCovFramework/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib";

--- a/swiftcov.xcodeproj/project.pbxproj
+++ b/swiftcov.xcodeproj/project.pbxproj
@@ -386,6 +386,8 @@
 		D0D1211019E87861005E4BAA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0720;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = SwiftCov;
 				TargetAttributes = {

--- a/swiftcov.xcodeproj/project.pbxproj
+++ b/swiftcov.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 			attributes = {
 				LastSwiftMigration = 0720;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = SwiftCov;
 				TargetAttributes = {
 					D0D1216C19E87B05005E4BAA = {
@@ -514,6 +514,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0D1212619E878CC005E4BAA /* Debug.xcconfig */;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
@@ -554,6 +555,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFramework;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -589,6 +591,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFramework;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -609,6 +612,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Source/SwiftCovFrameworkTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFrameworkTests;
 			};
 			name = Debug;
@@ -622,6 +626,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Source/SwiftCovFrameworkTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFrameworkTests;
 			};
 			name = Release;
@@ -659,6 +664,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFramework;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -679,6 +685,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Source/SwiftCovFrameworkTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFrameworkTests;
 			};
 			name = Profile;
@@ -716,6 +723,7 @@
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFramework;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -737,6 +745,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Source/SwiftCovFrameworkTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftCovFrameworkTests;
 			};
 			name = Test;
@@ -748,6 +757,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Source/swiftcov/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/../Frameworks @executable_path/SwiftCovFramework.framework/Versions/Current/Frameworks /Library/Frameworks /Library/Frameworks/SwiftCovFramework.framework/Versions/Current/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -759,6 +769,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Source/swiftcov/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/../Frameworks @executable_path/SwiftCovFramework.framework/Versions/Current/Frameworks /Library/Frameworks /Library/Frameworks/SwiftCovFramework.framework/Versions/Current/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Test;
@@ -770,6 +781,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Source/swiftcov/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/../Frameworks @executable_path/SwiftCovFramework.framework/Versions/Current/Frameworks /Library/Frameworks /Library/Frameworks/SwiftCovFramework.framework/Versions/Current/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -781,6 +793,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Source/swiftcov/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/. @executable_path/../Frameworks @executable_path/SwiftCovFramework.framework/Versions/Current/Frameworks /Library/Frameworks /Library/Frameworks/SwiftCovFramework.framework/Versions/Current/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.swiftcov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Profile;

--- a/swiftcov.xcodeproj/xcshareddata/xcschemes/SwiftCovFramework.xcscheme
+++ b/swiftcov.xcodeproj/xcshareddata/xcschemes/SwiftCovFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:swiftcov.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Profile"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Profile"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/swiftcov.xcodeproj/xcshareddata/xcschemes/swiftcov.xcscheme
+++ b/swiftcov.xcodeproj/xcshareddata/xcschemes/swiftcov.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,16 +48,19 @@
             ReferencedContainer = "container:swiftcov.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "NO"
       debugXPCServices = "NO"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "NO"
       viewDebuggingEnabled = "No">
       <BuildableProductRunnable
@@ -74,10 +77,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Profile"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Profile"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Since this hasn't been maintained in a while, I wanted to see how hard it would be to update to work with the latest versions of Xcode and Swift. After about an hour, I got most of it working, minus the actual code coverage generation part :sweat_smile:.

Regardless, I think we should deprecate this tool, prevent new GitHub issues from being filed and recommend that people use Swift 2.0's native test coverage capabilities. 

What do you think @kishikawakatsumi?
